### PR TITLE
Add pytest tests for PMICalculator

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -7,6 +7,7 @@
 - [Usage](#Usage)
 - [Training](#Training)
 - [Example](#Example)
+- [Testing](#Testing)
 - [License](#License)
 - [Links](#Links)
 
@@ -128,6 +129,14 @@ The three `print()` statements output the following:
 Remember that you must call the `train()` method with a suitable dataset before using the other `PMICalculator` methods.
 
 And that's it! You can now integrate the PMI Calculator repo with your application of choice.
+
+## Testing
+
+This repository includes a [pytest](https://docs.pytest.org/) test suite that verifies the `PMICalculator`'s `pmi`, `key_set`, and `count` methods. After cloning the repository and installing any desired dependencies, run the tests with:
+
+```
+pytest
+```
 
 ## License
 

--- a/tests/test_pmi.py
+++ b/tests/test_pmi.py
@@ -1,0 +1,25 @@
+import os
+import sys
+import pytest
+
+# Ensure pmi module is importable when tests are executed from any working directory
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+from pmi import PMICalculator
+
+@pytest.fixture
+def trained_calc():
+    corpus = [('A', ['x', 'y']), ('B', ['x'])]
+    calc = PMICalculator()
+    calc.train(corpus)
+    return calc
+
+def test_pmi_values(trained_calc):
+    assert trained_calc.pmi('A', 'x') == pytest.approx(0.75)
+    assert trained_calc.pmi('B', 'x') == pytest.approx(1.5)
+
+def test_key_set(trained_calc):
+    assert set(trained_calc.key_set('A')) == {'x', 'y'}
+
+def test_count(trained_calc):
+    assert trained_calc.count('x') == 2


### PR DESCRIPTION
## Summary
- add pytest test coverage for the PMICalculator's PMI, key_set, and count functions
- document the pytest suite in the README

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6893d8dfe8f88326ad17d859ff130fd3