### PR TITLE
Add one-line docstrings to functions

### DIFF
--- a/pmi.py
+++ b/pmi.py
@@ -8,6 +8,7 @@ class PMICalculator:
     """Compute pointwise mutual information for label-word pairs."""
 
     def __init__(self) -> None:
+        """Initialize the PMI calculator."""
         self.label_counts: defaultdict[str, float] = defaultdict(float)
         self.word_counts: defaultdict[str, float] = defaultdict(float)
         self.joint_counts: defaultdict[str, defaultdict[str, float]] = defaultdict(
@@ -18,6 +19,7 @@ class PMICalculator:
     def train(
         self, corpus: Iterable[tuple[str, Iterable[str]]], smoothing_factor: float = 0.0
     ) -> None:
+        """Populate counts from the corpus with optional smoothing."""
         self.label_counts = defaultdict(lambda: smoothing_factor)
         self.word_counts = defaultdict(lambda: smoothing_factor)
         self.joint_counts = defaultdict(lambda: defaultdict(lambda: smoothing_factor))
@@ -32,9 +34,11 @@ class PMICalculator:
                 self.num_pairs += 1
 
     def key_set(self, label: str) -> KeysView[str]:
+        """Return the set of words associated with a label."""
         return self.joint_counts[label].keys()
 
     def pmi(self, label: str, word: str) -> float:
+        """Calculate the PMI for a label and word."""
         joint_prob: float = float(self.joint_counts[label][word]) / float(
             self.num_pairs
         )
@@ -43,4 +47,5 @@ class PMICalculator:
         return joint_prob / (label_prob * word_prob)
 
     def count(self, word: str) -> float:
+        """Retrieve the observed count for a word."""
         return self.word_counts[word]

--- a/tests/test_pmi.py
+++ b/tests/test_pmi.py
@@ -7,6 +7,7 @@ from pmi import PMICalculator
 
 
 def test_pmi_counts_and_keyset() -> None:
+    """Test counting words and retrieving key sets."""
     corpus = [("label1", ["a", "b"]), ("label2", ["a"])]
     calc = PMICalculator()
     calc.train(corpus)
@@ -18,9 +19,28 @@ def test_pmi_counts_and_keyset() -> None:
 
 
 def test_smoothing_factor() -> None:
+    """Test applying a smoothing factor to unseen words."""
     corpus = [("x", ["y"])]
     calc = PMICalculator()
     calc.train(corpus, smoothing_factor=1.0)
 
     assert calc.count("missing") == 1.0
     assert "y" in calc.key_set("x")
+
+
+def test_expected_pmi_value() -> None:
+    """Test PMI equals the joint to marginal probability ratio."""
+    corpus = [("label1", ["a"]), ("label2", ["b"])]
+    calc = PMICalculator()
+    calc.train(corpus)
+
+    assert calc.pmi("label1", "a") == 2.0
+
+
+def test_unseen_pair_pmi_is_zero() -> None:
+    """Test PMI is zero for label-word pairs not in the corpus."""
+    corpus = [("label1", ["a"]), ("label2", ["b"])]
+    calc = PMICalculator()
+    calc.train(corpus)
+
+    assert calc.pmi("label1", "b") == 0.0


### PR DESCRIPTION
## Summary
- add concise docstrings to PMI calculator methods
- document test functions
- expand unit tests to cover PMI value calculations and unseen pairs

## Testing
- `uv run pre-commit run --files tests/test_pmi.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6893ef48a4c88326bf8c2b0833641357