### PR TITLE
Add pytest tests for PMICalculator

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -7,6 +7,7 @@
 - [Usage](#Usage)
 - [Training](#Training)
 - [Example](#Example)
+- [Testing](#Testing)
 - [License](#License)
 - [Links](#Links)
 
@@ -128,6 +129,18 @@ The three `print()` statements output the following:
 Remember that you must call the `train()` method with a suitable dataset before using the other `PMICalculator` methods.
 
 And that's it! You can now integrate the PMI Calculator repo with your application of choice.
+
+## Testing
+
+Unit tests are provided in the `tests` directory and can be run with
+[`pytest`](https://docs.pytest.org). From the project root, execute:
+
+```
+pytest -q
+```
+
+The tests verify word counts, key sets, and PMI calculations using a
+sample corpus.
 
 ## License
 

--- a/tests/test_pmi.py
+++ b/tests/test_pmi.py
@@ -1,0 +1,33 @@
+import math
+import sys
+from pathlib import Path
+
+# Ensure the project root is on the Python path for imports
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from pmi import PMICalculator
+
+
+def build_calculator():
+    calc = PMICalculator()
+    corpus = [
+        ("label1", ["word1", "word2"]),
+        ("label2", ["word1"]),
+    ]
+    calc.train(corpus)
+    return calc
+
+
+def test_count_and_key_set():
+    calc = build_calculator()
+    assert calc.count("word1") == 2
+    assert calc.count("word2") == 1
+    assert set(calc.key_set("label1")) == {"word1", "word2"}
+    assert set(calc.key_set("label2")) == {"word1"}
+
+
+def test_pmi_values():
+    calc = build_calculator()
+    assert math.isclose(calc.pmi("label1", "word1"), 0.75)
+    assert math.isclose(calc.pmi("label2", "word1"), 1.5)
+    assert math.isclose(calc.pmi("label1", "word2"), 1.5)


### PR DESCRIPTION
## Summary
- add unit tests for PMICalculator counts and PMI calculations
- document how to run the test suite in README

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6893d96595848326ae8d2f3c01c56dd8